### PR TITLE
Fix cassert accidentally wiped from merge

### DIFF
--- a/src/Swoosh/Shaders.h
+++ b/src/Swoosh/Shaders.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <SFML/Graphics.hpp>
-#include <assert>
+#include <cassert>
 
 /*
 All of the pre-defined transition effects use common shaders


### PR DESCRIPTION
The "header change only" 12f76a1fc2eb7e998a71181417096259555f08ab edit appears to have accidentally wiped the "\<assert\> to \<cassert\>" 21a026fcea60b5e093c10e73784a534923c9ac93 change