### PR TITLE
Update ActivityController.h

### DIFF
--- a/src/Swoosh/ActivityController.h
+++ b/src/Swoosh/ActivityController.h
@@ -289,9 +289,9 @@ namespace swoosh {
     template <class T>
     struct IsSegueType
     {
-      static char is_to(swoosh::Activity*) {}
+      static char is_to(swoosh::Activity*) { return 0; }
 
-      static double is_to(...) { ; }
+      static double is_to(...) { ; return 0; }
 
       static T* t;
 


### PR DESCRIPTION
add `retrun 0;` at ligne 292 and ligne 294 to avoid compilation warning when making a build.