### PR TITLE
Fix buffer overflow

### DIFF
--- a/src/Swoosh/EmbedGLSL.h
+++ b/src/Swoosh/EmbedGLSL.h
@@ -49,7 +49,7 @@ namespace swoosh {
       char* input = new char[size];
       char delim[] = ";";
       memcpy(input, glsl, size);
-      input[size] = '\0';
+      input[size - 1] = '\0';
 
       rsize_t strmax = sizeof input;
       char* next_token{};


### PR DESCRIPTION
In EmbedGLSL.h, input[size] results in a buffer overflow.  input[size - 1] changes the correct character to null-terminate the string.

Also, thanks for this library!